### PR TITLE
fix: release off the release branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,58 @@
+name: Main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 1.8.4
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+
+      - name: Install project
+        run: poetry install --no-interaction
+
+      - name: Run tests
+        run: |
+          source $VENV
+          pytest tests --exitfirst --verbose --failed-first --cov-report term --cov-report xml:coverage.xml --cov=newspy
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        continue-on-error: true
+        with:
+          fail_ci_if_error: true
+          files: ./coverage.xml
+          verbose: true
+
+      - name: Create Pull Request (if none exists)
+        run: |
+          existing_pr=$(gh pr list --base release --head main --search "Merge main into release" --state open --limit 1)
+          if [ -z "$existing_pr" ]; then
+            echo "No existing PR found. Creating a new one."
+            gh pr create --title "Merge main into release" --body "This PR merges changes from the main branch into the release branch." --base release --head main
+          else
+            echo "Pull Request already exists. Skipping creation."
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,53 +1,12 @@
 name: Pre-release
 
 on:
-  pull_request:
-    types: [ closed ]
+  push:
     branches:
-      - main
+      - release
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up python
-        id: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.13
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: 1.8.4
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
-
-      - name: Install dependencies
-        run: poetry install --no-interaction --no-root
-
-      - name: Install project
-        run: poetry install --no-interaction
-
-      - name: Run tests
-        run: |
-          source $VENV
-          pytest tests --exitfirst --verbose --failed-first --cov-report term --cov-report xml:coverage.xml --cov=newspy
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        continue-on-error: true
-        with:
-          fail_ci_if_error: true
-          files: ./coverage.xml
-          verbose: true
-
-  version:
-    needs: test
+  versioning:
     permissions:
       contents: write
       issues: read
@@ -56,11 +15,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Switch to release branch
+        run: git checkout release
 
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: 23.1.0
+          node-version: 22.11.0
           cache: 'yarn'
 
       - name: Install dependencies


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for the main branch and modifies the existing pre-release workflow. The changes streamline the CI/CD processes by adding automated testing and coverage reporting for the main branch and simplifying the pre-release workflow.

New workflow for main branch:

* Created a new workflow in `.github/workflows/main.yml` to run tests and upload coverage reports on pushes to the `main` branch. This workflow includes steps for setting up Python, installing dependencies with Poetry, running tests with pytest, and uploading coverage reports to Codecov. Additionally, it includes a step to automatically create a pull request to merge changes from `main` into `release` if no such PR exists.

Modifications to pre-release workflow:

* Updated `.github/workflows/pre-release.yml` to trigger on pushes to the `release` branch instead of closed pull requests. Removed the test job and retained only the versioning job.
* Added steps in the pre-release workflow to fetch the full git history and switch to the `release` branch before proceeding with the versioning steps.