### PR TITLE
ci: add workflow permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,12 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: write
+      pull-requests: write
+
     runs-on: ubuntu-latest
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: write
       issues: read
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,8 @@ on:
 jobs:
   deploy:
     permissions:
-      contents: write
+      contents: read
+      id-token: write
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to adjust permissions for various jobs.

Changes to permissions in GitHub Actions workflows:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R10-R15): Added `contents: write` and `pull-requests: write` permissions to the `test` job.
* [`.github/workflows/pre-release.yml`](diffhunk://#diff-8f0c4d810b263ab478547020c847ee0297cc98c11c67fc2209ce604e52719607R13): Added a newline for better readability in the `permissions` section of the `jobs` configuration.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L9-R10): Changed `contents` permission from `write` to `read` and added `id-token: write` permission for the `deploy` job.