### PR TITLE
ci: run codeql on pull request only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,8 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  schedule:
-    - cron: '25 16 * * 4'
 
 jobs:
   analyze:


### PR DESCRIPTION
This pull request updates the CodeQL workflow configuration to streamline the analysis process.

Changes to CodeQL workflow:

* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L4-L9): Removed the `push` event trigger and the scheduled cron job, leaving only the `pull_request` event trigger for the `main` branch.