### PR TITLE
fix(workflow): specify the release branch on the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: release
+          token: '${{ secrets.GITHUB_TOKEN }}'
 
       - name: Extract branch or tag name
         id: ref
@@ -39,16 +43,19 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
-      - name: Update version
+      - name: Configure Git
         run: |
-          poetry version ${{ env.VERSION }}
-          
           git config --global user.name "newspy"
           git config --global user.email "newspy@youremail.com"
-          
+          git checkout release
+
+      - name: Bump version
+        run: |
+          poetry version ${{ env.VERSION }}
+
           git add pyproject.toml
           git commit -m "chore: bump version to ${{ env.VERSION }}"
-          git push origin main
+          git push origin release
 
       - name: Install dependencies
         run: poetry install --no-interaction --no-root


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/release.yml` file to improve the release workflow by adding necessary Git configurations and modifying the version bump process.

Workflow improvements:

* Added `fetch-depth`, `ref`, and `token` parameters to the `Checkout` step to ensure the correct branch is checked out and all history is fetched.
* Renamed and updated the `Update version` step to `Configure Git`, including setting up Git user configurations and checking out the `release` branch.
* Added a new `Bump version` step to update the project version using `poetry`, commit the changes, and push to the `release` branch instead of `main`.