### PR TITLE
fix(workflow): revert release workflow. bump up version before build …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   deploy:
     permissions:
-      contents: read
+      contents: write
 
     runs-on: ubuntu-latest
 
@@ -42,6 +42,19 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
+      - name: Configure Git
+        run: |
+          git config --global user.name "newspy"
+          git config --global user.email "newspy@youremail.com"
+
+      - name: Bump version
+        run: |
+          poetry version ${{ env.VERSION }}
+
+          git add pyproject.toml
+          git commit -m "chore: bump version to ${{ env.VERSION }}"
+          git push origin release
+
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
 
@@ -49,5 +62,3 @@ jobs:
         run: |
           poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
           poetry publish --build
-        env:
-          POETRY_VERSION: ${{ env.VERSION }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for releases to include version bumping and proper Git configuration. The most important changes are:

### Workflow Configuration:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L9-R9): Changed `contents` permission from `read` to `write` for the `deploy` job.

### Job Steps:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R45-L53): Added steps to configure Git user name and email.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R45-L53): Added a step to bump the version using `poetry`, commit the change, and push it to the `release` branch.…and publish step