### PR TITLE
chore: update Poetry version to 2.1.2 in CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.4
+          version: 2.1.2
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.4
+          version: 2.1.2
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version: 1.8.4
+          version: 2.1.2
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true


### PR DESCRIPTION
This pull request includes updates to the Poetry installation version across multiple GitHub workflow files to ensure consistency and use of the latest features.

Updates to Poetry version:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL38-R38): Updated Poetry version from 1.8.4 to 2.1.2.
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L29-R29): Updated Poetry version from 1.8.4 to 2.1.2.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L40-R40): Updated Poetry version from 1.8.4 to 2.1.2.