### PR TITLE
News rss

### DIFF
--- a/newspy/rss/client.py
+++ b/newspy/rss/client.py
@@ -40,7 +40,7 @@ def get_articles(
         for future in as_completed(futures):
             resp_json = future.result()
 
-            if resp_json:
+            if resp_json and isinstance(resp_json, list):
                 for article in resp_json:
                     source = filter(lambda s: s.url == article["source_url"], sources)
                     articles.append(

--- a/newspy/shared/http_client.py
+++ b/newspy/shared/http_client.py
@@ -110,7 +110,7 @@ class HttpClient:
             match content_type:
                 case "application/json":
                     results = response.json()
-                case "application/rss+xml":
+                case "application/rss+xml" | "application/xml" | "text/xml":
                     results = parse_xml(data=response.content, source_url=url)
                 case "application/zip":
                     results = response.content

--- a/tests/rss/test_client.py
+++ b/tests/rss/test_client.py
@@ -95,8 +95,6 @@ def test_get_rss_articles_return_none(rss_articles_res_broken_xml) -> None:
 
 @responses.activate
 def test_get_rss_articles_handles_string_response() -> None:
-    """Test that get_articles handles string responses (like error pages) gracefully."""
-    # Simulate an error page being returned as plain text instead of RSS XML
     responses.add(
         **{
             "method": responses.GET,
@@ -118,7 +116,6 @@ def test_get_rss_articles_handles_string_response() -> None:
         )
     ]
 
-    # This should not raise a TypeError and should return an empty list
     actual = rss.get_articles(sources=rss_sources)
 
     assert actual == []
@@ -126,8 +123,6 @@ def test_get_rss_articles_handles_string_response() -> None:
 
 @responses.activate
 def test_get_rss_articles_handles_none_response() -> None:
-    """Test that get_articles handles None responses gracefully."""
-    # Simulate a response that returns None
     responses.add(
         **{
             "method": responses.GET,
@@ -149,10 +144,63 @@ def test_get_rss_articles_handles_none_response() -> None:
         )
     ]
 
-    # This should not raise a TypeError and should return an empty list
     actual = rss.get_articles(sources=rss_sources)
 
     assert actual == []
+
+
+@responses.activate
+def test_get_rss_articles_handles_http_exception(rss_articles_res_xml) -> None:
+    responses.add(
+        **{
+            "method": responses.GET,
+            "url": "https://feeds.a.dj.com/rss/RSSMarketsMain.xml",
+            "json": {
+                "error": {"message": "Service unavailable", "reason": "server_error"}
+            },
+            "status": 503,
+            "content_type": "application/json",
+        }
+    )
+
+    responses.add(
+        **{
+            "method": responses.GET,
+            "url": "https://feeds.a.dj.com/rss/WSJcomUSBusiness.xml",
+            "body": rss_articles_res_xml,
+            "status": 200,
+            "content_type": "application/rss+xml",
+        }
+    )
+
+    rss_sources = [
+        RssSource(
+            id="wsj-markets",
+            name="The Wall Street Journal Markets",
+            description="The Wall Street Journal (WSJ) Markets RSS",
+            url="https://feeds.a.dj.com/rss/RSSMarketsMain.xml",
+            category=Category.FINANCIAL,
+            language=Language.EN,
+        ),
+        RssSource(
+            id="wsj-business",
+            name="The Wall Street Journal Business",
+            description="The Wall Street Journal (WSJ) Business RSS",
+            url="https://feeds.a.dj.com/rss/WSJcomUSBusiness.xml",
+            category=Category.BUSINESS,
+            language=Language.EN,
+        ),
+    ]
+
+    actual = rss.get_articles(sources=rss_sources)
+
+    assert len(actual) == 2
+    assert all(article.source.id == "wsj-business" for article in actual)
+    assert (
+        actual[0].title
+        == "Three global cities are pulling ahead since the peak of the pandemic"
+    )
+    assert actual[1].title == "UK seeks to tap Middle East money to buy out SVB unit"
 
 
 def test_get_rss_sources_from_local_path() -> None:
@@ -180,7 +228,7 @@ def test_get_rss_sources_from_local_path() -> None:
 
 
 def test_get_rss_sources_from_invalid_path() -> None:
-    actual = rss.get_sources(file_path=123)  # type: ignore
+    actual = rss.get_sources(file_path=123)
 
     assert actual == []
 
@@ -290,6 +338,6 @@ def test_get_rss_resources_from_remote_path():
 
 
 def test_get_rss_resources_from_invalid_path():
-    actual = rss.get_sources(file_path=123)  # type: ignore
+    actual = rss.get_sources(file_path=123)
 
     assert actual == []

--- a/tests/rss/test_client.py
+++ b/tests/rss/test_client.py
@@ -93,6 +93,68 @@ def test_get_rss_articles_return_none(rss_articles_res_broken_xml) -> None:
     assert actual == []
 
 
+@responses.activate
+def test_get_rss_articles_handles_string_response() -> None:
+    """Test that get_articles handles string responses (like error pages) gracefully."""
+    # Simulate an error page being returned as plain text instead of RSS XML
+    responses.add(
+        **{
+            "method": responses.GET,
+            "url": "https://feeds.a.dj.com/rss/RSSMarketsMain.xml",
+            "body": "<html><body>404 Not Found</body></html>",
+            "status": 200,
+            "content_type": "text/html",
+        }
+    )
+
+    rss_sources = [
+        RssSource(
+            id="wsj-markets",
+            name="The Wall Street Journal Markets",
+            description="The Wall Street Journal (WSJ) Markets RSS",
+            url="https://feeds.a.dj.com/rss/RSSMarketsMain.xml",
+            category=Category.FINANCIAL,
+            language=Language.EN,
+        )
+    ]
+
+    # This should not raise a TypeError and should return an empty list
+    actual = rss.get_articles(sources=rss_sources)
+
+    assert actual == []
+
+
+@responses.activate
+def test_get_rss_articles_handles_none_response() -> None:
+    """Test that get_articles handles None responses gracefully."""
+    # Simulate a response that returns None
+    responses.add(
+        **{
+            "method": responses.GET,
+            "url": "https://feeds.a.dj.com/rss/RSSMarketsMain.xml",
+            "body": "",
+            "status": 200,
+            "content_type": "application/rss+xml",
+        }
+    )
+
+    rss_sources = [
+        RssSource(
+            id="wsj-markets",
+            name="The Wall Street Journal Markets",
+            description="The Wall Street Journal (WSJ) Markets RSS",
+            url="https://feeds.a.dj.com/rss/RSSMarketsMain.xml",
+            category=Category.FINANCIAL,
+            language=Language.EN,
+        )
+    ]
+
+    # This should not raise a TypeError and should return an empty list
+    actual = rss.get_articles(sources=rss_sources)
+
+    assert actual == []
+
+
 def test_get_rss_sources_from_local_path() -> None:
     expected = [
         RssSource(


### PR DESCRIPTION
This pull request improves the robustness and reliability of the RSS client by enhancing error handling, expanding content type support, and adding comprehensive tests to cover new edge cases. The changes ensure that the client gracefully handles various response types and errors, and that its behavior is well-tested.

**Error handling improvements:**
- Added logging and exception handling in `get_articles` to skip sources that raise a `NewspyException` and log a warning, preventing the entire process from failing due to one problematic source. [[1]](diffhunk://#diff-b83229a42affbd86d45f37d8b74c1209afbd369a24b707b1c94e7c07d0b9bd77R3) [[2]](diffhunk://#diff-b83229a42affbd86d45f37d8b74c1209afbd369a24b707b1c94e7c07d0b9bd77R12-R17) [[3]](diffhunk://#diff-b83229a42affbd86d45f37d8b74c1209afbd369a24b707b1c94e7c07d0b9bd77R45-R51)

**Content type handling:**
- Updated the HTTP client to recognize additional XML content types (`application/xml`, `text/xml`) when parsing RSS feeds, making the client more flexible with different server responses.

**Testing enhancements:**
- Added new tests to verify that `get_articles` correctly handles cases where the response is a string (e.g., HTML error page), `None`, or an HTTP error, ensuring it returns an empty list or skips sources as appropriate.
- Minor updates to existing tests to remove unnecessary type ignores and improve clarity. [[1]](diffhunk://#diff-9ca2dcd896753cd4a2e35df68a976524a0370889befcac9affa7aeb0bb82b21cL121-R231) [[2]](diffhunk://#diff-9ca2dcd896753cd4a2e35df68a976524a0370889befcac9affa7aeb0bb82b21cL231-R341)