### PR TITLE
fix(tests): add type ignore for invalid file path in get_sources tests

### DIFF
--- a/tests/rss/test_client.py
+++ b/tests/rss/test_client.py
@@ -228,7 +228,7 @@ def test_get_rss_sources_from_local_path() -> None:
 
 
 def test_get_rss_sources_from_invalid_path() -> None:
-    actual = rss.get_sources(file_path=123)
+    actual = rss.get_sources(file_path=123)  # type: ignore
 
     assert actual == []
 
@@ -338,6 +338,6 @@ def test_get_rss_resources_from_remote_path():
 
 
 def test_get_rss_resources_from_invalid_path():
-    actual = rss.get_sources(file_path=123)
+    actual = rss.get_sources(file_path=123)  # type: ignore
 
     assert actual == []


### PR DESCRIPTION
This pull request makes minor updates to the RSS client tests by adding type ignore comments to lines where an invalid file path type is intentionally passed. This helps suppress type checker warnings for these specific test cases.