### PR TITLE
fix(client): set User-Agent header for HTTP requests in client

### DIFF
--- a/newspy/rss/client.py
+++ b/newspy/rss/client.py
@@ -34,7 +34,9 @@ def get_articles(
                 http_client.send,
                 method=HttpMethod.GET,
                 url=source.url,
-                headers=None,
+                headers={
+                    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+                },
                 params=None,
                 payload=None,
             )


### PR DESCRIPTION
This pull request updates the HTTP client behavior in the `get_articles` function to improve compatibility with certain RSS sources. The main change is the addition of a custom `User-Agent` header to HTTP requests.

HTTP request compatibility:

* [`newspy/rss/client.py`](diffhunk://#diff-b83229a42affbd86d45f37d8b74c1209afbd369a24b707b1c94e7c07d0b9bd77L37-R39): Added a browser-like `User-Agent` header to HTTP GET requests in the `get_articles` function to ensure better compatibility with RSS sources that require a standard browser user agent.