### PR TITLE
fix(client): allow configurable User-Agent via environment variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,24 @@ jobs:
           git config --global user.name "newspy"
           git config --global user.email "newspy@youremail.com"
 
+      - name: Install Playwright and get user-agent
+        run: |
+          pip install playwright
+          playwright install chromium
+          
+          USER_AGENT=$(python -c "
+          from playwright.sync_api import sync_playwright
+          with sync_playwright() as p:
+              browser = p.chromium.launch()
+              page = browser.new_page()
+              ua = page.evaluate('navigator.userAgent')
+              browser.close()
+              print(ua)
+          ")
+          
+          echo "BROWSER_USER_AGENT=$USER_AGENT" >> $GITHUB_ENV
+          echo "Extracted User-Agent: $USER_AGENT"
+
       - name: Bump version
         run: |
           poetry version ${{ env.VERSION }}
@@ -59,6 +77,8 @@ jobs:
         run: poetry install --no-interaction --no-root
 
       - name: Build and publish
+        env:
+          USER_AGENT: ${{ env.BROWSER_USER_AGENT }}
         run: |
           poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
           poetry publish --build

--- a/newspy/rss/client.py
+++ b/newspy/rss/client.py
@@ -2,6 +2,7 @@ import csv
 import gzip
 import logging
 import io
+import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import NewType
@@ -11,7 +12,10 @@ from newspy.rss.models import RssSource, RssArticle
 from newspy.shared.http_client import HttpClient, HttpMethod
 from newspy.shared.exceptions import NewspyException
 
-DEFAULT_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36"
+DEFAULT_USER_AGENT = os.getenv(
+    "USER_AGENT",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36",
+)
 URL = NewType("URL", str)
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This pull request introduces dynamic detection and usage of the browser user-agent string in both the CI workflow and the application code. The main goal is to ensure that the application and its release process use an up-to-date and accurate user-agent string, improving compatibility and reducing the likelihood of being blocked by web servers.

**CI/CD Workflow Enhancements:**

* The release workflow now installs Playwright, launches a headless Chromium browser, extracts its user-agent string, and sets it as an environment variable (`BROWSER_USER_AGENT`) for subsequent steps.
* The build and publish step in the workflow now passes the extracted user-agent string as the `USER_AGENT` environment variable, ensuring that the built package can access this dynamic value if needed.

**Application Code Improvements:**

* In `newspy/rss/client.py`, the default user-agent is now set using the `USER_AGENT` environment variable (falling back to a static value if not set), allowing for dynamic configuration based on the environment. [[1]](diffhunk://#diff-b83229a42affbd86d45f37d8b74c1209afbd369a24b707b1c94e7c07d0b9bd77R5) [[2]](diffhunk://#diff-b83229a42affbd86d45f37d8b74c1209afbd369a24b707b1c94e7c07d0b9bd77L14-R18)