### PR TITLE
Workflow PR Message Cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,6 @@ jobs:
           - [ ] Review the changes included in this release.
           - [ ] Ensure all tests are passing.
           - [ ] Update documentation if necessary.
-          - [ ] Bump version numbers if not already done.
 
           Once reviewed and approved, merge this PR to update the \`release\` branch."
 


### PR DESCRIPTION
This pull request makes a small update to the release checklist in the `.github/workflows/main.yml` file by removing the step to bump version numbers if not already done. This simplifies the checklist for releases.

Reason: versioning is automated